### PR TITLE
allow requires to include any word character plus _ and -

### DIFF
--- a/lib/modulr/js_module.rb
+++ b/lib/modulr/js_module.rb
@@ -52,7 +52,7 @@ module Modulr
     end
 
     def identifier_valid?
-      @valid ||= terms.all? { |t| t =~ /^([a-zA-Z]+|\.\.?)$/ }
+      @valid ||= terms.all? { |t| t =~ /^([-_\w]+|\.\.?)$/ }
     end
     
     def id


### PR DESCRIPTION
I'm unable to find a reference in any common js spec.  But in node.js, for instance, it's common to see _'s.
