### PR TITLE
module.exports

### DIFF
--- a/assets/modulr.js
+++ b/assets/modulr.js
@@ -86,6 +86,7 @@ var modulr = (function(global) {
         if (typeof fn === 'string') {
           fn = new Function('require', 'exports', 'module', fn);
         }
+        mod.exports = expts;
         fn(require, expts, mod);
         _dirStack.pop();
       } catch(e) {
@@ -94,7 +95,7 @@ var modulr = (function(global) {
         throw e;
       }
     }
-    return expts;
+    return mod.exports;
   }
   
   function resolveIdentifier(identifier) {

--- a/assets/modulr.sync.js
+++ b/assets/modulr.sync.js
@@ -68,6 +68,7 @@ var require = (function() {
           fn = new Function('require', 'exports', 'module', fn);
         }
         if (!require.main) { require.main = mod; }
+        mod.exports = expts;
         fn(require, expts, mod);
         _dirStack.pop();
       } catch(e) {
@@ -76,7 +77,7 @@ var require = (function() {
         throw e;
       }
     }
-    return expts;
+    return mod.exports;
   }
   
   function resolveIdentifier(identifier) {


### PR DESCRIPTION
Although I don't think this is part of the CommonJS 1.0 module spec, Node does specify that `module.exports` represents the same object as `exports` (http://nodejs.org/api.html#module-53) and few popular libraries that work in browser and node environments use that pattern https://github.com/documentcloud/underscore/blob/master/underscore.js#L53 for example.

This patch lets modulr require libraries that either extend the exports object or replace it entirely by setting module.exports to a new object.

I wasn't sure where to put a test for this, since the feature isn't included  in the `/commonjs` submodule for acceptance testing.
